### PR TITLE
don't add sly-company automatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ your `~/.emacs` or `~/.emacs.d/init/el` init file is:
 (add-hook 'sly-mode-hook 'sly-company-mode)
 ```
 
+You need to add `company-sly` backend to `company-backends` manually:
+
+```el
+(add-to-list 'company-backends 'sly-company)
+```
+
 Optionally, use `M-x sly-company-mode` in the buffers where you want
 completion to happen.
 

--- a/sly-company.el
+++ b/sly-company.el
@@ -161,11 +161,6 @@ is recommended."
     ('sorted
      (eq sly-company-completion 'fuzzy))))
 
-;; Automatically add `sly-company' to `company-backends' on library
-;; load. It's a noop unless `sly-company-mode' is non-nil.
-;; 
-(add-to-list 'company-backends 'sly-company)
-
 (provide 'sly-company)
 
 ;;; sly-company.el ends here


### PR DESCRIPTION
This adding is globally. If user has other way to adding extra
company-backend. This global adding way will break user's settings.
