### PR TITLE
Fix fuzzy completion

### DIFF
--- a/sly-company.el
+++ b/sly-company.el
@@ -87,7 +87,7 @@ is recommended."
   (let ((package (sly-current-package)))
     (lambda (callback)
       (sly-eval-async
-          `(slynk:simple-completions ,prefix ',package)
+          `(slynk-completion:simple-completions ,prefix ',package)
         (lambda (result)
           (funcall callback (cl-first result)))
         package))))
@@ -96,7 +96,7 @@ is recommended."
   (let ((package (sly-current-package)))
     (lambda (callback)
       (sly-eval-async
-          `(slynk:fuzzy-completions ,prefix ',package)
+          `(slynk-completion:flex-completions ,prefix ',package)
         (lambda (result)
           (funcall callback
                    (mapcar (lambda (completion)


### PR DESCRIPTION
Since the function was renamed in Slynk, I've also renamed it here. As the `flex-completions` function is not exported from the Slynk package, I changed the package name here as well. I'll open a pull request to export the function, and as I don't know MELPA enough to be certain that both MELPA packages would be updated in the same time, will make another pull request to change the package name back here later.

A temporary workaround that can be used to get fuzzy completion working in Emacs:

```Emacs Lisp
(defun change-completion-function (original-function &rest arguments)
  (when (eql (caar arguments) 'slynk:fuzzy-completions)
    (setf (caar arguments) 'slynk-completion:flex-completions))
  (apply original-function arguments))

(advice-add 'sly-eval-async :around #'change-completion-function)
```